### PR TITLE
clear additional properties

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -233,7 +233,6 @@ def set_movie_properties(json_response):
     title_header = "[B]" + str(json_response['result']['setdetails']['limits']['total']) + " " + xbmc.getLocalizedString(20342) + "[/B][CR]"
     for item in json_response['result']['setdetails']['movies']:
         art = item['art']
-        streaminfo = media_streamdetails(item['file'].encode('utf-8').lower(), item['streamdetails'])
         window.setProperty('Set.Movie.%d.DBID' % count, str(item.get('movieid')))
         window.setProperty('Set.Movie.%d.Title' % count, item['label'])
         window.setProperty('Set.Movie.%d.Plot' % count, item['plot'])
@@ -241,7 +240,6 @@ def set_movie_properties(json_response):
         window.setProperty('Set.Movie.%d.Path' % count, media_path(item['file']))
         window.setProperty('Set.Movie.%d.Year' % count, str(item['year']))
         window.setProperty('Set.Movie.%d.Duration' % count, str(item['runtime'] / 60))
-        window.setProperty('Set.Movie.%d.VideoResolution' % count, streaminfo["videoresolution"])
         window.setProperty('Set.Movie.%d.Art(clearlogo)' % count, art.get('clearlogo', ''))
         window.setProperty('Set.Movie.%d.Art(discart)' % count, art.get('discart', ''))
         window.setProperty('Set.Movie.%d.Art(fanart)' % count, art.get('fanart', ''))
@@ -302,6 +300,8 @@ def clear_properties():
         window.clearProperty('Set.Movies.Writer')
         window.clearProperty('Set.Movies.Director')
         window.clearProperty('Set.Movies.Genre')
+        window.clearProperty('Set.Movies.Country')
+        window.clearProperty('Set.Movies.Studio')
         window.clearProperty('Set.Movies.Years')
         window.clearProperty('Set.Movies.Count')
     else:


### PR DESCRIPTION
Clear properties for sets country and studio

Currently when focus moves from a set to a movie (for example, viewing movie titles with "view movies in sets") , several properties are cleared but Set.Movies.Country and Set.Movies.Studio are not cleared.  This PR adds window.clearProperty statements for both of these