### PR TITLE
Use revised Kodi booleans in vers 17+

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -120,7 +120,7 @@ def GetStringFromUrl(encurl):
 
 
 def Notify(header, line='', line2='', line3=''):
-    xbmc.executebuiltin('Notification(%s, %s, %s, %s)' % (header, line, line2, line3))
+    xbmc.executebuiltin('Notification(%s, %s)' % (header, line))
 
 
 def prettyprint(string):

--- a/default.py
+++ b/default.py
@@ -8,6 +8,7 @@ ADDON = xbmcaddon.Addon()
 ADDON_VERSION = ADDON.getAddonInfo('version')
 WND = xbmcgui.Window(12003)  # Video info dialog
 HOME = xbmcgui.Window(10000)  # Home Window
+KODI_NEW = bool(int(xbmc.getInfoLabel("System.BuildVersion")[:2]) > 16)
 
 
 class Daemon:
@@ -36,7 +37,9 @@ class Daemon:
                             self._set_artist_details(self.selecteditem)
                         elif xbmc.getCondVisibility("Container.Content(albums)"):
                             self._set_album_details(self.selecteditem)
-                        elif xbmc.getCondVisibility("SubString(ListItem.Path,videodb://movies/sets/,left)"):
+                        elif KODI_NEW and xbmc.getCondVisibility("String.Contains(ListItem.Path,videodb://movies/sets/)"):
+                            self._set_movieset_details(self.selecteditem)
+                        elif (not KODI_NEW) and xbmc.getCondVisibility("SubString(ListItem.Path,videodb://movies/sets/,left)"):
                             self._set_movieset_details(self.selecteditem)
                         elif xbmc.getCondVisibility("Container.Content(movies)"):
                             self._set_movie_details(self.selecteditem)
@@ -186,7 +189,11 @@ try:
     params = dict(arg.split("=") for arg in sys.argv[1].split("&"))
 except:
     params = {}
-if xbmc.getCondVisibility("IsEmpty(Window(home).Property(skininfos_daemon_running))"):
+if KODI_NEW and xbmc.getCondVisibility("String.IsEmpty(Window(home).Property(skininfos_daemon_running))"):
+    xbmc.executebuiltin('SetProperty(skininfos_daemon_running,True,home)')
+    log("starting daemon")
+    Daemon()
+elif  (not KODI_NEW) and xbmc.getCondVisibility("IsEmpty(Window(home).Property(skininfos_daemon_running))"):
     xbmc.executebuiltin('SetProperty(skininfos_daemon_running,True,home)')
     log("starting daemon")
     Daemon()


### PR DESCRIPTION
1.  SubString() and IsEmpty() deprecated in Kodi 17 and removed in Kodi 18
2.  Notification dialog only allows 1 text line? 